### PR TITLE
Remove unnecessary #extension directive

### DIFF
--- a/source/blender/draw/engines/eevee/shaders/lights_lib.glsl
+++ b/source/blender/draw/engines/eevee/shaders/lights_lib.glsl
@@ -1,10 +1,7 @@
-
 #pragma BLENDER_REQUIRE(common_math_lib.glsl)
 #pragma BLENDER_REQUIRE(common_math_geom_lib.glsl)
 #pragma BLENDER_REQUIRE(raytrace_lib.glsl)
 #pragma BLENDER_REQUIRE(ltc_lib.glsl)
-
-#extension GL_ARB_texture_gather : enable
 
 #ifndef MAX_CASCADE_NUM
 #  define MAX_CASCADE_NUM 4


### PR DESCRIPTION
This should fix shader compile errors for Mesa drivers on Linux, however I was able to only test this on Intel GPUs.
The extension looks to be also enabled automatically in [`source/blender/gpu/opengl/gl_shader.cc:817`](https://github.com/dillongoostudios/goo-engine/blob/8e66abfbc4f4392ff1996ed589cd26fbe94d2327/source/blender/gpu/opengl/gl_shader.cc#L817).

Fixes #3.
