### PR TITLE
Add eevee view layer sample override

### DIFF
--- a/scripts/startup/bl_ui/properties_view_layer.py
+++ b/scripts/startup/bl_ui/properties_view_layer.py
@@ -46,6 +46,7 @@ class VIEWLAYER_PT_layer(ViewLayerButtonsPanel, Panel):
         col = layout.column()
         col.prop(layer, "use", text="Use for Rendering")
         col.prop(rd, "use_single_layer", text="Render Single Layer")
+        col.prop(layer, "samples", text="Sample Override")
 
 
 class VIEWLAYER_PT_layer_passes(ViewLayerButtonsPanel, Panel):

--- a/source/blender/draw/engines/eevee/eevee_engine.c
+++ b/source/blender/draw/engines/eevee/eevee_engine.c
@@ -164,7 +164,14 @@ static void eevee_cache_finish(void *vedata)
   EEVEE_volumes_draw_init(sldata, vedata);
 
   uint tot_samples = scene_eval->eevee.taa_render_samples;
+  uint vl_samples = draw_ctx->view_layer->samples;
+
+  if (vl_samples > 0){
+    tot_samples = vl_samples;
+  }
+  
   if (tot_samples == 0) {
+
     /* Use a high number of samples so the outputs accumulation buffers
      * will have the highest possible precision. */
     tot_samples = 1024;

--- a/source/blender/draw/engines/eevee/eevee_temporal_sampling.c
+++ b/source/blender/draw/engines/eevee/eevee_temporal_sampling.c
@@ -218,7 +218,17 @@ void EEVEE_temporal_sampling_create_view(EEVEE_Data *vedata)
 int EEVEE_temporal_sampling_sample_count_get(const Scene *scene, const EEVEE_StorageList *stl)
 {
   const bool is_render = DRW_state_is_image_render();
-  int sample_count = is_render ? scene->eevee.taa_render_samples : scene->eevee.taa_samples;
+  const DRWContextState *draw_ctx = DRW_context_state_get();
+
+  uint render_samples = scene->eevee.taa_render_samples;
+  uint vl_samples = draw_ctx->view_layer->samples;
+
+  if (vl_samples > 0){
+    render_samples = vl_samples;
+  }
+
+  int sample_count = is_render ? render_samples : scene->eevee.taa_samples;
+
   int timesteps = is_render ? stl->g_data->render_timesteps : 1;
 
   sample_count = max_ii(0, sample_count);


### PR DESCRIPTION
Reuses the view layer samples property used in cycles for eevee rendering
