### PR TITLE
GooEngine: Add toggle for custom line width in viewport.

### DIFF
--- a/release/datafiles/userdef/userdef_default.c
+++ b/release/datafiles/userdef/userdef_default.c
@@ -71,6 +71,8 @@ const UserDef U_default = {
     .pixelsize = 1,
     .virtual_pixel = 0,
 
+    .viewport_line_width = 1.0,
+
     .scrollback = 256,
     .node_margin = 80,
     .transopts = USER_TR_TOOLTIPS,

--- a/scripts/startup/bl_ui/space_userpref.py
+++ b/scripts/startup/bl_ui/space_userpref.py
@@ -201,6 +201,7 @@ class USERPREF_PT_interface_display(InterfacePanel, CenterAlignMixIn, Panel):
 
         col.prop(view, "ui_scale", text="Resolution Scale")
         col.prop(view, "ui_line_width", text="Line Width")
+        col.prop(view, "viewport_line_width", text="Viewport Line Width")
         col.prop(view, "show_splash", text="Splash Screen")
         col.prop(view, "show_developer_ui")
 

--- a/source/blender/draw/engines/overlay/overlay_antialiasing.cc
+++ b/source/blender/draw/engines/overlay/overlay_antialiasing.cc
@@ -64,7 +64,7 @@ void OVERLAY_antialiasing_init(OVERLAY_Data *vedata)
     return;
   }
 
-  bool need_wire_expansion = (G_draw.block.size_pixel > 1.0f);
+  bool need_wire_expansion = (G_draw.block.size_pixel > 1.0f) || (G_draw.block.size_viewport_line > 1.0f);
   pd->antialiasing.enabled = need_wire_expansion ||
                              ((U.gpu_flag & USER_GPU_FLAG_OVERLAY_SMOOTH_WIRE) != 0);
 

--- a/source/blender/draw/engines/overlay/shaders/overlay_antialiasing_frag.glsl
+++ b/source/blender/draw/engines/overlay/shaders/overlay_antialiasing_frag.glsl
@@ -85,7 +85,7 @@ void neighbor_blend(
 void main()
 {
   ivec2 center_texel = ivec2(gl_FragCoord.xy);
-  float line_kernel = sizePixel * 0.5 - 0.5;
+  float line_kernel = sizeLine * 0.5 - 0.5;
 
   fragColor = texelFetch(colorTex, center_texel, 0);
 

--- a/source/blender/draw/intern/draw_common.c
+++ b/source/blender/draw/intern/draw_common.c
@@ -170,6 +170,7 @@ void DRW_globals_update(void)
   gb->size_light_center = (UI_GetThemeValuef(TH_OBCENTER_DIA) + 1.5f) * U.pixelsize;
   gb->size_light_circle = U.pixelsize * 9.0f;
   gb->size_light_circle_shadow = gb->size_light_circle + U.pixelsize * 3.0f;
+  gb->size_viewport_line = max_ff(U.viewport_line_width, 1.0f);
 
   /* M_SQRT2 to be at least the same size of the old square */
   gb->size_vertex = U.pixelsize *

--- a/source/blender/draw/intern/draw_common_shader_shared.h
+++ b/source/blender/draw/intern/draw_common_shader_shared.h
@@ -133,6 +133,8 @@ struct GlobalsUboStorage {
   float size_vertex, size_edge, size_edge_fix, size_face_dot;
   float size_checker;
   float size_vertex_gpencil;
+  float size_viewport_line;
+  float _pad0, _pad1, _pad2;
 };
 BLI_STATIC_ASSERT_ALIGN(GlobalsUboStorage, 16)
 
@@ -243,6 +245,7 @@ BLI_STATIC_ASSERT_ALIGN(GlobalsUboStorage, 16)
 #  define sizeFaceDot globalsBlock.size_face_dot
 #  define sizeChecker globalsBlock.size_checker
 #  define sizeVertexGpencil globalsBlock.size_vertex_gpencil
+#  define sizeLine globalsBlock.size_viewport_line
 #endif
 
 /* See: 'draw_cache_impl.h' for matching includes. */

--- a/source/blender/makesdna/DNA_userdef_types.h
+++ b/source/blender/makesdna/DNA_userdef_types.h
@@ -772,6 +772,9 @@ typedef struct UserDef {
   /** Deprecated, for forward compatibility. */
   int virtual_pixel;
 
+  float viewport_line_width;
+  char _pad14[4];
+
   /** Console scroll-back limit. */
   int scrollback;
   /** Node insert offset (aka auto-offset) margin, but might be useful for later stuff as well. */

--- a/source/blender/makesrna/intern/rna_userdef.c
+++ b/source/blender/makesrna/intern/rna_userdef.c
@@ -4639,6 +4639,12 @@ static void rna_def_userdef_view(BlenderRNA *brna)
       "Changes the thickness of widget outlines, lines and dots in the interface");
   RNA_def_property_update(prop, 0, "rna_userdef_dpi_update");
 
+  prop = RNA_def_property(srna, "viewport_line_width", PROP_FLOAT, PROP_NONE);
+  RNA_def_property_ui_text(
+      prop, "Viewport Line Width", "Changes the appearance of only lines in the 3D viewport");
+  RNA_def_property_range(prop, 1.0f, 3.0f);
+  RNA_def_property_update(prop, 0, "rna_userdef_dpi_update");
+
   /* display */
   prop = RNA_def_property(srna, "show_tooltips", PROP_BOOLEAN, PROP_NONE);
   RNA_def_property_boolean_sdna(prop, NULL, "flag", USER_TOOLTIPS);


### PR DESCRIPTION
Adds a new property to the user preferences to set the DPI for viewport line drawing separately from the rest of the UI. Affects all lines drawn in the viewport (since the line expansion is a post-process effect on the whole scene)