### PR TITLE
GooEngine: Add Start Frame and End Frame to Scene Time node

### DIFF
--- a/source/blender/nodes/geometry/nodes/node_geo_input_scene_time.cc
+++ b/source/blender/nodes/geometry/nodes/node_geo_input_scene_time.cc
@@ -12,15 +12,21 @@ static void node_declare(NodeDeclarationBuilder &b)
 {
   b.add_output<decl::Float>("Seconds");
   b.add_output<decl::Float>("Frame");
+  b.add_output<decl::Float>("Start Frame");
+  b.add_output<decl::Float>("End Frame");
 }
 
 static void node_exec(GeoNodeExecParams params)
 {
   const Scene *scene = DEG_get_input_scene(params.depsgraph());
+  const float scene_sfra = scene->r.sfra;
+  const float scene_efra = scene->r.efra;
   const float scene_ctime = BKE_scene_ctime_get(scene);
   const double frame_rate = (double(scene->r.frs_sec) / double(scene->r.frs_sec_base));
   params.set_output("Seconds", float(scene_ctime / frame_rate));
   params.set_output("Frame", scene_ctime);
+  params.set_output("Start Frame", scene_sfra);
+  params.set_output("End Frame", scene_efra);
 }
 
 }  // namespace blender::nodes::node_geo_input_scene_time_cc


### PR DESCRIPTION
Adds a Start Frame and End Frame option to the Scene Time node.

This repository is only used as a mirror. Blender development happens on projects.blender.org.

To get started with contributing code, please see:
https://wiki.blender.org/wiki/Process/Contributing_Code
