### PR TITLE
GooEngine: Option to disable Material Icon rendering

### DIFF
--- a/scripts/startup/bl_ui/space_userpref.py
+++ b/scripts/startup/bl_ui/space_userpref.py
@@ -2433,6 +2433,7 @@ class USERPREF_PT_experimental_debugging(ExperimentalPanel, Panel):
                 ({"property": "show_asset_debug_info"}, None),
                 ({"property": "use_asset_indexing"}, None),
                 ({"property": "use_viewport_debug"}, None),
+                ({"property": "disable_material_icon"}, None),
             ),
         )
 

--- a/source/blender/editors/interface/interface_icons.cc
+++ b/source/blender/editors/interface/interface_icons.cc
@@ -1438,6 +1438,11 @@ static void icon_set_image(const bContext *C,
                            enum eIconSizes size,
                            const bool use_job)
 {
+  if (U.experimental.disable_material_icon && GS(id->name) == ID_MA) {
+    return;
+  }
+
+
   if (!prv_img) {
     if (G.debug & G_DEBUG) {
       printf("%s: no preview image for this ID: %s\n", __func__, id->name);

--- a/source/blender/makesdna/DNA_userdef_types.h
+++ b/source/blender/makesdna/DNA_userdef_types.h
@@ -664,6 +664,7 @@ typedef struct UserDef_Experimental {
   char no_asset_indexing;
   char use_viewport_debug;
   char use_all_linked_data_direct;
+  char disable_material_icon;
   char SANITIZE_AFTER_HERE;
   /* The following options are automatically sanitized (set to 0)
    * when the release cycle is not alpha. */
@@ -677,7 +678,7 @@ typedef struct UserDef_Experimental {
   char use_sculpt_texture_paint;
   char enable_workbench_next;
   char use_new_volume_nodes;
-  char _pad[6];
+  char _pad[5];
   /** `makesdna` does not allow empty structs. */
 } UserDef_Experimental;
 

--- a/source/blender/makesrna/intern/rna_userdef.c
+++ b/source/blender/makesrna/intern/rna_userdef.c
@@ -6601,6 +6601,15 @@ static void rna_def_userdef_experimental(BlenderRNA *brna)
                            "reduces execution time and memory usage)");
   RNA_def_property_update(prop, 0, "rna_userdef_update");
 
+  prop = RNA_def_property(srna, "disable_material_icon", PROP_BOOLEAN, PROP_NONE);
+  RNA_def_property_boolean_sdna(prop, NULL, "disable_material_icon", 1);
+  RNA_def_property_ui_text(
+      prop,
+      "Disable Material Icon Rendering",
+      "If true, Material Preview Icons will NOT be rendered. "
+      "This can prevent stuttering from opening the material ID menu");
+
+
   prop = RNA_def_property(srna, "use_new_curves_tools", PROP_BOOLEAN, PROP_NONE);
   RNA_def_property_boolean_sdna(prop, NULL, "use_new_curves_tools", 1);
   RNA_def_property_ui_text(


### PR DESCRIPTION
Option is in the "Experimental" user preferences, which needs "Developer Extras" checked to access, since it's a bit more niche of a setting.