### PR TITLE
GooEngine: Fix crash with Material Icon Rendering disabled

### DIFF
--- a/source/blender/editors/interface/interface_icons.cc
+++ b/source/blender/editors/interface/interface_icons.cc
@@ -1438,7 +1438,7 @@ static void icon_set_image(const bContext *C,
                            enum eIconSizes size,
                            const bool use_job)
 {
-  if (U.experimental.disable_material_icon && GS(id->name) == ID_MA) {
+  if (U.experimental.disable_material_icon && id != nullptr && GS(id->name) == ID_MA) {
     return;
   }
 


### PR DESCRIPTION
Certain addons provide their own icons to draw in their UI (eg. Polyhaven's addon). The `id` is a `nullptr` in such cases and will crash Blender, this commit just provides a simple check.
