### PR TITLE
Fix links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@ Goo Engine
 Goo Engine is a version of Blender by [DillonGoo Studios](https://www.youtube.com/dillongoo) with some key modifications
 to the source code that allow us to focus on NPR and Anime style rendering. Key features include the four custom Shader 
 nodes we added to Eevee and Light Groups. You can learn about them on the 
-[Professor Goo YouTube channel](https://www.youtube.com/@professorGoo>).
+[Professor Goo YouTube channel](https://www.youtube.com/@professorGoo).
 
 Some have asked why we haven't pushed these changes to Blender's master branch: 
 this is because many of these features would not be accepted as they are and may destablize other features like Cycles.
 We only use Eevee for NPR so we prioritize specific features which the Blender Institute understandably can't afford to 
 make compromises for. This allows us to develop and test quickly. However, we do actively update Goo Engine to keep up 
 with the native Blender branch so they can evolve side by side. We also regularly add and improve custom features as we 
-use Goo Engine on projects at the studio. [Stay tuned](https://twitter.com/dillongoostudio>) for updates.
+use Goo Engine on projects at the studio. [Stay tuned](https://twitter.com/dillongoostudio) for updates.
 
 Get the pre-built download on the [Patreon page](https://www.patreon.com/dillongoo) to support continued development of 
 Goo Engine.


### PR DESCRIPTION
Some links have accidental > symbols in the end.

