### PR TITLE
Enable contact shadows by default

### DIFF
--- a/source/blender/makesdna/DNA_light_defaults.h
+++ b/source/blender/makesdna/DNA_light_defaults.h
@@ -24,7 +24,7 @@
     .energy_deprecated = 10.0f, \
     .spotsize = DEG2RADF(45.0f), \
     .spotblend = 0.15f, \
-    .mode = LA_SHADOW, \
+    .mode = LA_SHADOW | LA_SHAD_CONTACT, \
     .clipsta = 0.05f, \
     .clipend = 40.0f, \
     .bias = 1.0f, \


### PR DESCRIPTION
This option fixes light leakage using SSR, its better to keep this on when creating new lights