### PR TITLE
Fix MSVC C++17 build

### DIFF
--- a/source/blender/editors/object/object_constraint.cc
+++ b/source/blender/editors/object/object_constraint.cc
@@ -2290,10 +2290,9 @@ static int pose_constraints_merge_exec(bContext *C, wmOperator *op)
       num_cons += 1;
       const bConstraintTypeInfo *cti = BKE_constraint_typeinfo_get(con);
 
-      struct IDRelinkUserData userdata = {
-              .src_object = (ID *) obact,
-              .dst_object = (ID *) pose_ob,
-      };
+      struct IDRelinkUserData userdata{};
+      userdata.src_object = reinterpret_cast<ID*>(obact);
+      userdata.dst_object = reinterpret_cast<ID*>(pose_ob);
 
       if (cti->id_looper) {
         cti->id_looper(con, con_relink_id_cb, &userdata);


### PR DESCRIPTION
```
D:\a\goo-engine\goo-engine\source\blender\editors\object\object_constraint.cc(2288,15): error C7555: use of designated initializers requires at least '/std:c++20' [D:\a\goo-engine\build_windows_x64_vc17_Release\source\blender\editors\object\bf_editor_object.vcxproj]
```
