### PR TITLE
Upstream: `Build: Ambiguous call to isfinite for MSVC 17.11`

### DIFF
--- a/intern/cycles/scene/image.cpp
+++ b/intern/cycles/scene/image.cpp
@@ -28,20 +28,6 @@ CCL_NAMESPACE_BEGIN
 
 namespace {
 
-/* Some helpers to silence warning in templated function. */
-bool isfinite(uchar /*value*/)
-{
-  return true;
-}
-bool isfinite(half /*value*/)
-{
-  return true;
-}
-bool isfinite(uint16_t /*value*/)
-{
-  return true;
-}
-
 const char *name_from_type(ImageDataType type)
 {
   switch (type) {
@@ -628,7 +614,7 @@ bool ImageManager::file_load_image(Image *img, int texture_limit)
   }
 
   /* Make sure we don't have buggy values. */
-  if (FileFormat == TypeDesc::FLOAT) {
+  if constexpr (FileFormat == TypeDesc::FLOAT) {
     /* For RGBA buffers we put all channels to 0 if either of them is not
      * finite. This way we avoid possible artifacts caused by fully changed
      * hue. */


### PR DESCRIPTION
Fixes build for new MSVC versions.

```
D:\a\goo-blender\goo-blender\intern\cycles\scene\image.cpp(637,14): error C2668: 'ccl::`anonymous-namespace'::isfinite': ambiguous call to overloaded function [D:\a\goo-blender\build_windows_x64_vc17_Release\intern\cycles\scene\cycles_scene.vcxproj]
    D:\a\goo-blender\goo-blender\intern\cycles\scene\image.cpp(40,6):
    could be 'bool ccl::`anonymous-namespace'::isfinite(uint16_t)'
    D:\a\goo-blender\goo-blender\intern\cycles\scene\image.cpp(36,6):
    or       'bool ccl::`anonymous-namespace'::isfinite(ccl::half)'
    D:\a\goo-blender\goo-blender\intern\cycles\scene\image.cpp(32,6):
    or       'bool ccl::`anonymous-namespace'::isfinite(ccl::uchar)'
```

Original commit comment:

---

**Build: Ambiguous call to `isfinite` for MSVC 17.11**

Overload resolution must have changed and is causing issues for one particular code path attempting to use `isfinite(ccl::uchar)`. Compiler output attached.

It turns out that the code in question can be simplified to just remove the ambiguity because only the float codepath wants to check for finite values.

----

Reduced repro: https://godbolt.org/z/YWz3Yc3x8
Pull Request: https://projects.blender.org/blender/blender/pulls/125348
