### PR TITLE
Change FragColor to gl_FragColor in shader

### DIFF
--- a/source/blender/draw/engines/gooengine/shaders/effect_minmaxz_frag.glsl
+++ b/source/blender/draw/engines/gooengine/shaders/effect_minmaxz_frag.glsl
@@ -57,7 +57,7 @@ void main()
 
 #if (defined(GPU_INTEL) || defined(GPU_ATI)) && defined(GPU_OPENGL)
   /* Use color format instead of 24bit depth texture */
-  FragColor = vec4(val);
+  gl_FragColor = vec4(val);
 #endif
 
 #if !(defined(GPU_INTEL) && defined(GPU_OPENGL))


### PR DESCRIPTION
This fixes an issue on AMD GPUs (GPU_ATI) where Blender Goo Engine 4.4.3 crashes when entering render view under the Goo Engine render engine, triggering an error of `'FragColor' : undeclared identifier` in `eevee_legacy_maxz_downlevel`. For some reason this was tolerated in earlier versions of Blender but not in 4.4.

Note: while this seems to work properly in a release build, on a debug build in Visual Studio it breaks on a debug assert at [goo-engine\source\blender\draw\intern\draw_command.cc](https://github.com/dillongoostudios/goo-engine/blob/76af2f3ac090bd62728e1d33c292d02e61334a4b/source/blender/draw/intern/draw_command.cc#L297) saying that `DST.state_lock` hasn't been properly zeroed out. I'm not sure if this is anything to be concerned about as I tested several of my existing projects and the renders came out exactly how I would expect them to.